### PR TITLE
Fixed Incorrect Cross-Referencing

### DIFF
--- a/docs/Validated Exploitable Data Flow (VXDF) Format.md
+++ b/docs/Validated Exploitable Data Flow (VXDF) Format.md
@@ -50,16 +50,16 @@ By achieving these goals, VXDF v1.0 intends to significantly improve how validat
 
 The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119\.
 
-* **AffectedComponent (**ExploitFlow.affectedComponents\[\]**)**: An object that describes a specific software component, library, hardware device, configuration file, service, or other asset that is implicated in the vulnerability. It includes identifiers like PURL or CPE, version, and componentType. This is crucial for non-flow based vulnerabilities or to specify the primary components involved in any vulnerability. (See $defs/AffectedComponent in Appendix A: Normative JSON Schema and Appendix N for componentType definitions ).  
+* **AffectedComponent (**ExploitFlow.affectedComponents\[\]**)**: An object that describes a specific software component, library, hardware device, configuration file, service, or other asset that is implicated in the vulnerability. It includes identifiers like PURL or CPE, version, and componentType. This is crucial for non-flow based vulnerabilities or to specify the primary components involved in any vulnerability. (See $defs/AffectedComponent in Appendix A: Normative JSON Schema and Appendix O for componentType definitions ).  
 * **ApplicationInfo (**VXDFPayload.applicationInfo**)**: An object within the VXDF document root that provides metadata about the application, system, or product that was assessed, including its name, version, and identifiers like PURL or CPE. (See applicationInfo property in Appendix A: Normative JSON Schema ).  
-* **Category (**ExploitFlow.category**)**: A string field providing a high-level classification of the vulnerability type (e.g., "INJECTION", "BROKEN\_ACCESS\_CONTROL"). A list of recommended categories and their descriptions is provided in Appendix I.  
+* **Category (**ExploitFlow.category**)**: A string field providing a high-level classification of the vulnerability type (e.g., "INJECTION", "BROKEN\_ACCESS\_CONTROL"). A list of recommended categories and their descriptions is provided in Appendix J.  
 * **CorrelationGuid (**ExploitFlow.correlationGuids\[\]**)**: A globally unique identifier used to correlate an ExploitFlow with related findings or entries in other systems or formats (e.g., a result.correlationGuid from a SARIF report).
 
 * **CWE (Common Weakness Enumeration)**: A standardized identifier for types of software and hardware weaknesses. VXDF ExploitFlows can reference one or more CWE identifiers to precisely classify the nature of the weakness.  
 * **CustomProperties (**customProperties**)**: Designated objects within various VXDF structures (e.g., VXDFPayload, ExploitFlow, Evidence) that allow producers to include arbitrary additional key-value data not covered by the standard fields. Keys within customProperties should ideally be namespaced.  
-* **Evidence (**ExploitFlow.evidence\[\]**)**: A mandatory component of every ExploitFlow. It is an array of one or more Evidence objects, each providing structured, machine-readable proof that validates the exploitability of the vulnerability. Each Evidence object has an evidenceType and a corresponding structured data field. (See $defs/Evidence in Appendix A: Normative JSON Schema and Appendix P for evidenceType definitions ).  
+* **Evidence (**ExploitFlow.evidence\[\]**)**: A mandatory component of every ExploitFlow. It is an array of one or more Evidence objects, each providing structured, machine-readable proof that validates the exploitability of the vulnerability. Each Evidence object has an evidenceType and a corresponding structured data field. (See $defs/Evidence in Appendix A: Normative JSON Schema and Appendix Q for evidenceType definitions ).  
 * **EvidenceDataVariant (**Evidence.data**)**: The structured object within an Evidence item containing the detailed, machine-readable evidence content. The specific fields within this data object depend entirely on the evidenceType. (See $defs/EvidenceDataVariant and specific data schemas like $defs/HttpRequestLogData in Appendix A: Normative JSON Schema).  
-* **EvidenceType (**Evidence.evidenceType**)**: An enumerated string within an Evidence object that specifies the nature of the evidence provided (e.g., "HTTP\_REQUEST\_LOG", "POC\_SCRIPT", "CONFIGURATION\_FILE\_SNIPPET"). The value of evidenceType determines the expected schema for the corresponding Evidence.data object. (See Appendix P for definitions and data structure summaries ).  
+* **EvidenceType (**Evidence.evidenceType**)**: An enumerated string within an Evidence object that specifies the nature of the evidence provided (e.g., "HTTP\_REQUEST\_LOG", "POC\_SCRIPT", "CONFIGURATION\_FILE\_SNIPPET"). The value of evidenceType determines the expected schema for the corresponding Evidence.data object. (See Appendix Q for definitions and data structure summaries ).  
 * **ExploitFlow**: The central object in a VXDF document, representing a single, validated, exploitable vulnerability instance. It contains detailed information about the vulnerability's nature, location (either as a data flow via source/sink/steps or via affectedComponents), severity, and the evidence proving its exploitability. (Formerly referred to simply as "Flow" in earlier drafts; see $defs/ExploitFlow in Appendix A: Normative JSON Schema ).  
 * **Extension Field (**x- **prefix)**: An ad-hoc custom field within a VXDF JSON object, prefixed with x- (e.g., x-internal-tracking-id). These are used for data not fitting into standard fields or customProperties bags. Conforming consumers should ignore unrecognized x- fields. (See Appendix E: Extension Mechanism ).  
 * **GeneratedAt (**VXDFPayload.generatedAt**)**: An ISO 8601 date-time timestamp indicating when the VXDF document was generated.  
@@ -69,21 +69,21 @@ The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RE
 * **ID (ExploitFlow Identifier \-** ExploitFlow.id**)**: A UUID uniquely identifying a specific ExploitFlow instance within the VXDF document.  
 * **ID (Evidence Identifier \-** Evidence.id**)**: An optional UUID uniquely identifying a specific Evidence item, useful for cross-referencing.
 
-* **Location**: A detailed object used to describe a specific locus relevant to a vulnerability, such as a point in source code, a web endpoint parameter, a configuration file setting, or a software component. Its meaning is further qualified by its locationType property. (See $defs/Location in Appendix A: Normative JSON Schema and Appendix L for locationType definitions ).  
-* **LocationType (**Location.locationType**)**: An enumerated string within a Location object that specifies the nature of the resource or entity being identified (e.g., "SOURCE\_CODE\_UNIT", "WEB\_ENDPOINT\_PARAMETER", "SOFTWARE\_COMPONENT\_LIBRARY", "CONFIGURATION\_FILE\_SETTING"). (See Appendix L for definitions and usage guidance ).  
+* **Location**: A detailed object used to describe a specific locus relevant to a vulnerability, such as a point in source code, a web endpoint parameter, a configuration file setting, or a software component. Its meaning is further qualified by its locationType property. (See $defs/Location in Appendix A: Normative JSON Schema and Appendix M for locationType definitions ).  
+* **LocationType (**Location.locationType**)**: An enumerated string within a Location object that specifies the nature of the resource or entity being identified (e.g., "SOURCE\_CODE\_UNIT", "WEB\_ENDPOINT\_PARAMETER", "SOFTWARE\_COMPONENT\_LIBRARY", "CONFIGURATION\_FILE\_SETTING"). (See Appendix M for definitions and usage guidance ).  
 * **Remediation (**ExploitFlow.remediation**)**: An object providing guidance on how to remediate the vulnerability, including a summary and optional detailsUrl or codePatches.
 
-* **Severity (**ExploitFlow.severity**)**: A structured object representing the criticality and potential impact of the vulnerability. It MUST include a qualitative level (e.g., "CRITICAL", "HIGH") and MAY include detailed quantitative scoring using CVSS v3.1 and/or CVSS v4.0, along with a justification. (See $defs/Severity in Appendix A: Normative JSON Schema and Appendix J for level definitions ).  
+* **Severity (**ExploitFlow.severity**)**: A structured object representing the criticality and potential impact of the vulnerability. It MUST include a qualitative level (e.g., "CRITICAL", "HIGH") and MAY include detailed quantitative scoring using CVSS v3.1 and/or CVSS v4.0, along with a justification. (See $defs/Severity in Appendix A: Normative JSON Schema and Appendix K for level definitions ).  
 * **Sink (**ExploitFlow.sink**)**: (Primarily for flow-based vulnerabilities) A Location object describing the endpoint of a data flow where untrusted data or control is consumed in a way that manifests the exploit (e.g., a function executing a SQL query, code rendering unescaped data to HTML).  
 * **Source (**ExploitFlow.source**)**: (Primarily for flow-based vulnerabilities) A Location object describing the entry point of untrusted data or the origin of control that leads to the exploit (e.g., an HTTP request parameter, a function reading from a file).  
-* **Status (**ExploitFlow.status**)**: An enumerated string indicating the current stage of a validated vulnerability finding within a management or remediation lifecycle (e.g., "OPEN", "REMEDIATED", "ACCEPTED\_RISK"). (See Appendix K for definitions ).  
+* **Status (**ExploitFlow.status**)**: An enumerated string indicating the current stage of a validated vulnerability finding within a management or remediation lifecycle (e.g., "OPEN", "REMEDIATED", "ACCEPTED\_RISK"). (See Appendix L for definitions ).  
 * **Tags (**ExploitFlow.tags\[\]**)**: An array of custom string tags for additional categorization, filtering, or tracking of an ExploitFlow.  
 * **Title (**ExploitFlow.title**)**: A concise, human-readable title summarizing the vulnerability within an ExploitFlow.  
-* **TraceStep (**ExploitFlow.steps\[\]**)**: (Primarily for flow-based vulnerabilities) An object within the steps array of an ExploitFlow, describing an intermediate point in an ordered trace from source to sink. It includes an order, a Location object, a description, a stepType, and optional evidenceRefs. (Formerly referred to simply as "Step"; see $defs/TraceStep in Appendix A: Normative JSON Schema and Appendix M for stepType definitions ).  
+* **TraceStep (**ExploitFlow.steps\[\]**)**: (Primarily for flow-based vulnerabilities) An object within the steps array of an ExploitFlow, describing an intermediate point in an ordered trace from source to sink. It includes an order, a Location object, a description, a stepType, and optional evidenceRefs. (Formerly referred to simply as "Step"; see $defs/TraceStep in Appendix A: Normative JSON Schema and Appendix N for stepType definitions ).  
 * **ValidatedAt (**ExploitFlow.validatedAt**)**: An ISO 8601 date-time timestamp indicating when the vulnerability was validated as exploitable for a given ExploitFlow.  
 * **ValidationEngine (**ExploitFlow.validationEngine**)**: An object providing information about the tool, engine, or methodology primarily responsible for validating the exploitability of a finding in an ExploitFlow.
 
-* **ValidationMethod (**Evidence.validationMethod**)**: An enumerated string within an Evidence object that describes the primary technique or approach used to obtain or confirm that specific piece of evidence (e.g., "DYNAMIC\_ANALYSIS\_EXPLOIT", "MANUAL\_PENETRATION\_TESTING\_EXPLOIT", "SCA\_CONTEXTUAL\_VALIDATION"). (See Appendix O for definitions ).  
+* **ValidationMethod (**Evidence.validationMethod**)**: An enumerated string within an Evidence object that describes the primary technique or approach used to obtain or confirm that specific piece of evidence (e.g., "DYNAMIC\_ANALYSIS\_EXPLOIT", "MANUAL\_PENETRATION\_TESTING\_EXPLOIT", "SCA\_CONTEXTUAL\_VALIDATION"). (See Appendix P for definitions ).  
 * **VXDF Document (or VXDF File)**: A JSON document that conforms to this VXDF v1.0.0 specification and its normative schema, containing metadata (root properties) and one or more ExploitFlow objects.
 
 * **VXDFVersion (**VXDFPayload.vxdfVersion**)**: A string that specifies the version of the VXDF schema to which the document conforms. For this specification, it MUST be "1.0.0".
@@ -131,32 +131,32 @@ Each object within the exploitFlows array provides detailed information about a 
 * validationEngine (Object, Optional): Information about the tool, engine, or methodology primarily responsible for validating the exploitability of this finding.  
   * name (String, Mandatory): Name of the validation tool, engine, or method (e.g., "Manual Penetration Test by SecureTeam", "DAST Engine X v2.1", "Automated Exploit Verification Module").  
   * version (String, Optional): Version of the tool/engine, if applicable.  
-* severity (Object, Mandatory): A structured object detailing the severity of the vulnerability. (See $defs/Severity in Appendix A and definitions in Appendix J). This includes:  
+* severity (Object, Mandatory): A structured object detailing the severity of the vulnerability. (See $defs/Severity in Appendix A and definitions in Appendix K). This includes:  
   * level (String, Mandatory): A qualitative severity rating (e.g., "CRITICAL", "HIGH", "MEDIUM", "LOW", "INFORMATIONAL", "NONE").  
   * cvssV3\_1 (Object, Optional): Detailed CVSS v3.1 scoring information.  
   * cvssV4\_0 (Object, Optional): Detailed CVSS v4.0 scoring information.  
   * customScore (Object, Optional): For representing scores from other systems.  
   * justification (String, Optional): An explanation for the assigned severity.  
-* category (String, Mandatory): A high-level classification of the vulnerability type. It is STRONGLY RECOMMENDED to use values from the controlled vocabulary in Appendix I.  
+* category (String, Mandatory): A high-level classification of the vulnerability type. It is STRONGLY RECOMMENDED to use values from the controlled vocabulary in Appendix J.  
 * cwe (Array of Strings, Optional): An array of Common Weakness Enumeration (CWE) identifiers (e.g., \["CWE-89", "CWE-20"\]) relevant to this vulnerability.  
 * remediation (Object, Optional): Guidance on how to remediate the vulnerability.  
   * summary (String, Mandatory): A brief summary of the remediation advice.  
   * detailsUrl (String, Optional, URI Format): A URL pointing to more detailed remediation guidance.  
   * codePatches (Array of Objects, Optional): Suggested code patches or diffs.  
-* status (String, Optional, Default: "OPEN"): The current status of this vulnerability finding from a controlled vocabulary (e.g., "OPEN", "REMEDIATED", "ACCEPTED\_RISK"). (See Appendix K for definitions).  
+* status (String, Optional, Default: "OPEN"): The current status of this vulnerability finding from a controlled vocabulary (e.g., "OPEN", "REMEDIATED", "ACCEPTED\_RISK"). (See Appendix L for definitions).  
 * tags (Array of Strings, Optional): Custom tags for additional categorization, filtering, or tracking (e.g., "PCI", "PII\_EXPOSED", "SPRINT-23").  
 * **Describing the Vulnerability Locus**: An ExploitFlow SHOULD provide details using one or both of the following approaches:  
   * **Flow-Based Details** (for vulnerabilities involving data flow):  
-    * source (Object, Location, Optional): Describes the entry point of untrusted data or the starting point of the exploit. (See $defs/Location in Appendix A and Appendix L).  
-    * sink (Object, Location, Optional): Describes the point of exploitation where the vulnerability manifests. (See $defs/Location in Appendix A and Appendix L).  
-    * steps (Array of TraceStep Objects, Optional): An ordered sequence detailing the data flow or exploit path from source to sink. (See $defs/TraceStep in Appendix A and Appendix M).  
+    * source (Object, Location, Optional): Describes the entry point of untrusted data or the starting point of the exploit. (See $defs/Location in Appendix A and Appendix M).  
+    * sink (Object, Location, Optional): Describes the point of exploitation where the vulnerability manifests. (See $defs/Location in Appendix A and Appendix M).  
+    * steps (Array of TraceStep Objects, Optional): An ordered sequence detailing the data flow or exploit path from source to sink. (See $defs/TraceStep in Appendix A and Appendix N).  
   * **Component-Based Details** (essential for non-flow vulnerabilities, and can augment flow-based ones):  
-    * affectedComponents (Array of AffectedComponent Objects, Optional): Details specific software components, libraries, hardware, services, or configuration files that are vulnerable or contribute to the vulnerability. (See $defs/AffectedComponent in Appendix A and Appendix N).  
+    * affectedComponents (Array of AffectedComponent Objects, Optional): Details specific software components, libraries, hardware, services, or configuration files that are vulnerable or contribute to the vulnerability. (See $defs/AffectedComponent in Appendix A and Appendix O).  
   * *(Guidance: An ExploitFlow MUST provide substantive details using either both source and sink properties OR at least one item in the affectedComponents array. It MAY include both if appropriate.)*  
 * evidence (Array of Evidence Objects, Mandatory): This is a critical component, providing the proof of exploitability. At least one Evidence object MUST be present. Each Evidence object includes:  
   * id (String, Optional, UUID Format): A UUID uniquely identifying this evidence item.  
-  * evidenceType (String, Mandatory): An enumerated string indicating the kind of evidence provided (e.g., "HTTP\_REQUEST\_LOG", "POC\_SCRIPT"). (See Appendix P).  
-  * validationMethod (String, Optional): An enumerated string indicating how this evidence was obtained (e.g., "DYNAMIC\_ANALYSIS\_EXPLOIT"). (See Appendix O).  
+  * evidenceType (String, Mandatory): An enumerated string indicating the kind of evidence provided (e.g., "HTTP\_REQUEST\_LOG", "POC\_SCRIPT"). (See Appendix Q).  
+  * validationMethod (String, Optional): An enumerated string indicating how this evidence was obtained (e.g., "DYNAMIC\_ANALYSIS\_EXPLOIT"). (See Appendix P).  
   * description (String, Mandatory): A human-readable summary of this evidence item.  
   * timestamp (String, Optional, ISO 8601 Format): When this evidence was captured or observed.  
   * data (Object, Mandatory): A structured object containing the detailed, machine-readable evidence content, the schema for which depends entirely on the evidenceType.  
@@ -165,7 +165,7 @@ Each object within the exploitFlows array provides detailed information about a 
 
 **3\. Supporting Object Definitions**
 
-The ExploitFlow object utilizes several other complex objects to provide detailed information. These include Location, TraceStep, AffectedComponent, Severity (and its CVSS variants), and Evidence (and its data variants). The formal structures of these objects, including their properties, data types, and controlled vocabularies, are normatively defined in Appendix A: Normative JSON Schema and further described in their respective descriptive appendices (I-P).
+The ExploitFlow object utilizes several other complex objects to provide detailed information. These include Location, TraceStep, AffectedComponent, Severity (and its CVSS variants), and Evidence (and its data variants). The formal structures of these objects, including their properties, data types, and controlled vocabularies, are normatively defined in Appendix A: Normative JSON Schema and further described in their respective descriptive appendices (J-Q).
 
 **4\. Extensibility**
 
@@ -643,7 +643,7 @@ By defining a distinct media type, we make it easier for systems to recognize VX
 
           "type": "string",
 
-          "description": "A high-level classification of the vulnerability type. See Appendix I: \`ExploitFlow.category\` \- Recommended Values and Descriptions for details and recommended values."
+          "description": "A high-level classification of the vulnerability type. See Appendix J: \`ExploitFlow.category\` \- Recommended Values and Descriptions for details and recommended values."
 
         },
 
@@ -755,7 +755,7 @@ By defining a distinct media type, we make it easier for systems to recognize VX
 
           "default": "OPEN",
 
-          "description": "The current status of this vulnerability finding within a management lifecycle. See Appendix K: \`ExploitFlow.status\` \- Definitions for details."
+          "description": "The current status of this vulnerability finding within a management lifecycle. See Appendix L: \`ExploitFlow.status\` \- Definitions for details."
 
         },
 
@@ -979,7 +979,7 @@ By defining a distinct media type, we make it easier for systems to recognize VX
 
           \],
 
-          "description": "The primary type of location being described. See Appendix L: \`Location.locationType\` \- Definitions and Usage Guidance for details on each type and their relevant properties."
+          "description": "The primary type of location being described. See Appendix M: \`Location.locationType\` \- Definitions and Usage Guidance for details on each type and their relevant properties."
 
         },
 
@@ -1393,7 +1393,7 @@ By defining a distinct media type, we make it easier for systems to recognize VX
 
           \],
 
-          "description": "The nature of this step in the flow. See Appendix M: \`TraceStep.stepType\` \- Definitions for details."
+          "description": "The nature of this step in the flow. See Appendix N: \`TraceStep.stepType\` \- Definitions for details."
 
         },
 
@@ -1517,7 +1517,7 @@ By defining a distinct media type, we make it easier for systems to recognize VX
 
           \],
 
-          "description": "The general type or category of the component. See Appendix N: \`AffectedComponent.componentType\` \- Definitions for details."
+          "description": "The general type or category of the component. See Appendix O: \`AffectedComponent.componentType\` \- Definitions for details."
 
         },
 
@@ -1597,7 +1597,7 @@ By defining a distinct media type, we make it easier for systems to recognize VX
 
           "enum": \["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFORMATIONAL", "NONE"\],
 
-          "description": "A qualitative severity level assigned to the vulnerability. See Appendix J: \`Severity.level\` \- Definitions for details."
+          "description": "A qualitative severity level assigned to the vulnerability. See Appendix K: \`Severity.level\` \- Definitions for details."
 
         },
 
@@ -2007,7 +2007,7 @@ By defining a distinct media type, we make it easier for systems to recognize VX
 
           \],
 
-          "description": "The type of evidence provided. The structure of the 'data' field depends on this type. See Appendix P: \`Evidence.evidenceType\` \- Definitions, Usage, and Data Structure Summaries for details."
+          "description": "The type of evidence provided. The structure of the 'data' field depends on this type. See Appendix Q: \`Evidence.evidenceType\` \- Definitions, Usage, and Data Structure Summaries for details."
 
         },
 
@@ -2045,7 +2045,7 @@ By defining a distinct media type, we make it easier for systems to recognize VX
 
           \],
 
-          "description": "The primary method used to obtain or validate this specific piece of evidence as proof of exploitability. See Appendix O: \`Evidence.validationMethod\` \- Definitions for details."
+          "description": "The primary method used to obtain or validate this specific piece of evidence as proof of exploitability. See Appendix P: \`Evidence.validationMethod\` \- Definitions for details."
 
         },
 

--- a/docs/Validated Exploitable Data Flow (VXDF) Format.md
+++ b/docs/Validated Exploitable Data Flow (VXDF) Format.md
@@ -42,7 +42,7 @@ VXDF was created to address specific pain points in application security validat
 
 * *Extensibility:* Recognize that different organizations or tools might have custom needs. The spec defines an extension mechanism (via vendor-specific `x-*` fields) to allow adding extra information without breaking compliance. One goal is to enable experimentation and domain-specific additions (e.g., adding a company’s internal risk score) while maintaining a core standard.
 
-* *Align with Existing Standards:* Where possible, reuse or map to concepts from existing standards (like SARIF for static analysis results, or CWEs for weakness classification) instead of reinventing terminology. VXDF aims to complement, not conflict with, widely adopted frameworks. An explicit goal is to ensure VXDF can be easily **mapped** to SARIF and linked to SBOMs (SPDX), which will aid adoption and integration (detailed in Appendix B).
+* *Align with Existing Standards:* Where possible, reuse or map to concepts from existing standards (like SARIF for static analysis results, or CWEs for weakness classification) instead of reinventing terminology. VXDF aims to complement, not conflict with, widely adopted frameworks. An explicit goal is to ensure VXDF can be easily **mapped** to SARIF and linked to SBOMs (SPDX), which will aid adoption and integration (detailed in Appendix C).
 
 By achieving these goals, VXDF v1.0 intends to significantly improve how validated security findings are documented and shared, ultimately reducing time-to-fix for critical vulnerabilities and fostering greater collaboration between security and development teams.
 
@@ -61,7 +61,7 @@ The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RE
 * **EvidenceDataVariant (**Evidence.data**)**: The structured object within an Evidence item containing the detailed, machine-readable evidence content. The specific fields within this data object depend entirely on the evidenceType. (See $defs/EvidenceDataVariant and specific data schemas like $defs/HttpRequestLogData in Appendix A: Normative JSON Schema).  
 * **EvidenceType (**Evidence.evidenceType**)**: An enumerated string within an Evidence object that specifies the nature of the evidence provided (e.g., "HTTP\_REQUEST\_LOG", "POC\_SCRIPT", "CONFIGURATION\_FILE\_SNIPPET"). The value of evidenceType determines the expected schema for the corresponding Evidence.data object. (See Appendix Q for definitions and data structure summaries ).  
 * **ExploitFlow**: The central object in a VXDF document, representing a single, validated, exploitable vulnerability instance. It contains detailed information about the vulnerability's nature, location (either as a data flow via source/sink/steps or via affectedComponents), severity, and the evidence proving its exploitability. (Formerly referred to simply as "Flow" in earlier drafts; see $defs/ExploitFlow in Appendix A: Normative JSON Schema ).  
-* **Extension Field (**x- **prefix)**: An ad-hoc custom field within a VXDF JSON object, prefixed with x- (e.g., x-internal-tracking-id). These are used for data not fitting into standard fields or customProperties bags. Conforming consumers should ignore unrecognized x- fields. (See Appendix E: Extension Mechanism ).  
+* **Extension Field (**x- **prefix)**: An ad-hoc custom field within a VXDF JSON object, prefixed with x- (e.g., x-internal-tracking-id). These are used for data not fitting into standard fields or customProperties bags. Conforming consumers should ignore unrecognized x- fields. (See Appendix F: Extension Mechanism ).  
 * **GeneratedAt (**VXDFPayload.generatedAt**)**: An ISO 8601 date-time timestamp indicating when the VXDF document was generated.  
 * **GeneratorTool (**VXDFPayload.generatorTool**)**: An object within the VXDF document root that identifies the tool, script, or process that generated the VXDF document, including its name and optional version.
 
@@ -169,7 +169,7 @@ The ExploitFlow object utilizes several other complex objects to provide detaile
 
 **4\. Extensibility**
 
-VXDF is designed to be extensible. Beyond the defined customProperties bags, if implementers need to include additional, tool-specific, or experimental data not covered by the standard schema, they MUST prefix such custom fields with x- (e.g., x-mytool-internal-score). Conforming VXDF consumers SHOULD ignore any x- prefixed fields they do not recognize, ensuring forward compatibility. (See Appendix E: Extension Mechanism).
+VXDF is designed to be extensible. Beyond the defined customProperties bags, if implementers need to include additional, tool-specific, or experimental data not covered by the standard schema, they MUST prefix such custom fields with x- (e.g., x-mytool-internal-score). Conforming VXDF consumers SHOULD ignore any x- prefixed fields they do not recognize, ensuring forward compatibility. (See Appendix F: Extension Mechanism).
 
 **Summary of Benefits of This Structure**
 
@@ -270,7 +270,7 @@ The normative VXDF v1.0.0 JSON Schema provided in this specification is the auth
   * Absence of disallowed additional properties (unless they are valid x- prefixed extensions or within customProperties bags).  
 * Outcome: If any validation check against the normative schema fails, the document is considered non-conformant.
 
-The VXDF project MAY provide a reference test suite (see Appendix F of the original "Validated Exploitable Data Flow (VXDF) Format MD.md" document concept) containing valid and invalid VXDF document examples to assist implementers in developing and verifying their conformance.
+The VXDF project MAY provide a reference test suite (see Appendix G) containing valid and invalid VXDF document examples to assist implementers in developing and verifying their conformance.
 
 In summary, a conformant VXDF ecosystem relies on producers generating schema-valid documents with accurate, evidence-backed vulnerability data, and consumers correctly interpreting this structured information. Adherence to these conformance rules ensures that VXDF can serve as a reliable and interoperable standard for communicating validated exploitable vulnerabilities.
 
@@ -4659,7 +4659,7 @@ vxdfutil convert \--from vxdf input.vxdf.json \--to csv output.csv \[--fields id
   * **SARIF to VXDF:** Converts SARIF result objects to VXDF ExploitFlows.  
     * A \--require-validation-info flag might mandate that the SARIF results have properties indicating validation, or the tool could prompt interactively for evidence details.  
     * If direct validation info is missing, Evidence objects might be created with evidenceType: "IMPORTED\_STATIC\_ANALYSIS\_FINDING" and validationMethod: "NOT\_VALIDATED\_BY\_VXDF\_PROCESSOR", with the SARIF message in Evidence.data. This clarifies that it's not yet a fully "VXDF-validated" entry.  
-  * **VXDF to SARIF:** Implements the mapping defined in Appendix B (Mapping to SARIF), embedding rich VXDF details (structured severity, full evidence array) into SARIF result.properties.  
+  * **VXDF to SARIF:** Implements the mapping defined in Appendix C (Mapping to SARIF), embedding rich VXDF details (structured severity, full evidence array) into SARIF result.properties.  
   * **VXDF to HTML/PDF:** Generates human-readable reports, rendering the structured Location, TraceStep, AffectedComponent, and Evidence (including its data) in a clear, navigable format.  
   * **VXDF to CSV/other formats:** For quick summaries or integration with spreadsheet-based tracking.  
 * **Purpose:** Facilitates data exchange and reporting in various contexts.
@@ -4777,7 +4777,7 @@ To ensure VXDF becomes a robust, widely-adopted standard, a clear governance mod
 
 * Part of governance is also promoting the standard. The VXDF working group should engage with relevant communities (OWASP vulnerability reporting groups, CERTs, software vendors, open-source projects) to evangelize the format.
 
-* The lifecycle includes periodic reviews of how well adoption is going (see Appendix H on success metrics) and adjusting strategy accordingly.
+* The lifecycle includes periodic reviews of how well adoption is going (see Appendix I on success metrics) and adjusting strategy accordingly.
 
 * There may be “plugfests” or interoperability tests organized where different tools exchange VXDF files to ensure consistency (for example, a static tool outputs VXDF and a dynamic tool reads it to perform validation).
 
@@ -4839,7 +4839,7 @@ VXDF supports two primary ways to include custom data:
 * **Data Types:** All extension data (values in customProperties or for x- fields) **MUST** be valid JSON data types (string, number, boolean, object, array, null).  
 * **Transition to Standard (for** x- **fields and common** customProperties **keys):**  
   * If an x- prefixed field or a key within customProperties proves to be broadly useful and adopted by a significant part of the community, it **SHOULD** be proposed for inclusion as a standard field in a future version of the VXDF specification.  
-  * The VXDF governance process (see Appendix D) will manage the review and potential adoption of such common extensions. This ensures the standard evolves based on real-world needs while preventing long-term fragmentation.  
+  * The VXDF governance process (see Appendix E) will manage the review and potential adoption of such common extensions. This ensures the standard evolves based on real-world needs while preventing long-term fragmentation.  
 * **Structured Extensions are Permitted:**  
   * Values within customProperties and the values of x- prefixed fields can be complex JSON objects or arrays, not just primitive types.
 


### PR DESCRIPTION
I fixed a systematic misreferencing of Appendices J through Q within the JSON schema descriptions (Appendix A ) and the Terminology section. These appendices define the controlled vocabularies for key enumerated fields. The references provided in the schema comments and terminology definitions consistently point to the wrong appendix letter.

I believe the root cause was that Appendix B was introduced withou changing the references to the other appendices. In the end, I also reviewed the other references (from B to H) as they also presented the same one-off error.